### PR TITLE
Feat: 비밀번호찾기 메일서버분리

### DIFF
--- a/src/main/java/com/grepp/synapse4/app/model/user/MailService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/MailService.java
@@ -20,20 +20,6 @@ public class MailService {
     @Qualifier("mailWebClient")
     private final WebClient mailWebClient;
 
-    public void sendTempPasswordEmail(String toEmail, String tempPassword) {
-        String subject = "[밥로드] 임시 비밀번호 안내";
-        String content = "요청하신 임시 비밀번호는 아래와 같습니다.\n\n"
-            + "임시 비밀번호: " + tempPassword + "\n\n"
-            + "로그인 후 반드시 비밀번호를 변경해주세요.";
-
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(toEmail);
-        message.setSubject(subject);
-        message.setText(content);
-
-        mailSender.send(message);
-    }
-
     // 메일서버로 요청
     public void sendToServerTempPasswordEmail(String toEmail, String tempPassword) {
         MailRequest request = new MailRequest(toEmail, tempPassword);

--- a/src/main/java/com/grepp/synapse4/app/model/user/MailService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/MailService.java
@@ -1,15 +1,24 @@
 package com.grepp.synapse4.app.model.user;
 
+import com.grepp.synapse4.app.model.user.mail.request.MailRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @RequiredArgsConstructor
 public class MailService {
 
     private final JavaMailSender mailSender;
+    // 밑에 태그는 현재 WebClientConfig 에
+    // 3개의 빈이 등록되어 어떤 빈을
+    // 호출할지 인식하지못해 명시적으로 선언해놨습니다.
+    @Qualifier("mailWebClient")
+    private final WebClient mailWebClient;
 
     public void sendTempPasswordEmail(String toEmail, String tempPassword) {
         String subject = "[밥로드] 임시 비밀번호 안내";
@@ -23,5 +32,17 @@ public class MailService {
         message.setText(content);
 
         mailSender.send(message);
+    }
+
+    // 메일서버로 요청
+    public void sendToServerTempPasswordEmail(String toEmail, String tempPassword) {
+        MailRequest request = new MailRequest(toEmail, tempPassword);
+
+        mailWebClient.post()
+                .uri("/mail/send")// 메일 서버 컨트로럴로 요청
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
     }
 }

--- a/src/main/java/com/grepp/synapse4/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/UserService.java
@@ -153,7 +153,7 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(tempPassword));
         userRepository.save(user);
 
-        mailService.sendTempPasswordEmail(user.getEmail(), tempPassword);
+        mailService.sendToServerTempPasswordEmail(user.getEmail(), tempPassword);
     }
 
     private String generateTempPassword() {

--- a/src/main/java/com/grepp/synapse4/app/model/user/mail/request/MailRequest.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/mail/request/MailRequest.java
@@ -1,0 +1,13 @@
+package com.grepp.synapse4.app.model.user.mail.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class MailRequest {
+    private final String toEmail;
+    private final String tempPassword;
+}

--- a/src/main/java/com/grepp/synapse4/infra/config/WebClientConfig.java
+++ b/src/main/java/com/grepp/synapse4/infra/config/WebClientConfig.java
@@ -24,5 +24,11 @@ public class WebClientConfig {
                 .baseUrl("https://generativelanguage.googleapis.com/v1")
                 .build();
     }
+    @Bean
+    public WebClient mailWebClient() {
+        return WebClient.builder()
+                .baseUrl("http://localhost:8083")
+                .build();
+    }
 
 }


### PR DESCRIPTION

## 📌 과제 설명

Feat: 비밀번호찾기 메일서버분리

## 👩‍💻 요구 사항과 구현 내용
메일서버는 코틀린으로 구현해 비밀번호 찾기시 mail-service로 api 호출로 body에 
email, password 넘겨주어 메일서버가 이메일을 보내주도록 하였습니다.

## ✅ 피드백 반영사항
