### PR TITLE
feat : 회원 탈퇴 시, meetingMember 및 voteMember creator 위임 또는 member 삭제

### DIFF
--- a/src/main/java/com/grepp/synapse4/app/model/meeting/MeetingService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/meeting/MeetingService.java
@@ -84,22 +84,7 @@ public class MeetingService {
     return meetingMemberRepository.countByMeetingIdAndState(id, State.ACCEPT);
   }
 
-  // 모임 탈퇴하기
-  @Transactional
-  public void leaveMeeting(Long id, Long userId) {
-    MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(id, userId)
-        .orElseThrow(() -> new RuntimeException("해당 멤버가 없습니다."));
 
-    meetingMemberRepository.delete(member);
-
-    // 멤버가 없을 시 모임 제거
-    int memberCount = meetingMemberRepository.countByMeetingId(id);
-    if(memberCount == 0){
-      Meeting meeting = meetingRepository.findById(id)
-          .orElseThrow(() -> new RuntimeException("모임을 찾지 못했습니다"));
-      meetingRepository.delete(meeting);
-    }
-  }
 
   // 모임 초대하기
   @Transactional
@@ -179,6 +164,7 @@ public class MeetingService {
     meetingRepository.deleteById(meetingId);
   }
 
+  @Transactional
   public void deleteByUser(User user) {
 
     // 1. meetingMem에서 user가 있는 모든 meeting id값 찾기
@@ -187,27 +173,66 @@ public class MeetingService {
     for(MeetingMember joinedMeeting : joinedMeetings){
       Meeting meeting = joinedMeeting.getMeeting();
 
-      // 2. 해당 meeting의 creatorId가 user인지 확인
-      if(meeting.getUser().getId().equals(user.getId())){
-        // 맞다면 user를 제외한 가장 오래된 ACCEPT 멤버 찾기
-        Optional<MeetingMember> oldestMember =
-                meetingMemberRepository.findTopByMeetingAndUserNotAndStateOrderByCreatedAtAsc(meeting, user, State.ACCEPT);
+      meetingMemberRepository.delete(joinedMeeting);
+      meetingMemberRepository.flush();
 
-        if(oldestMember.isPresent()){
-          // 멤버가 있다면, creatorId 위임
-          User newCreator = oldestMember.get().getUser();
-          meeting.setUser(newCreator);
-        } else{
-          // 멤버가 없다면, 아무도 없는 것이므로 meeting 자체를 삭제
-          meetingRepository.delete(meeting);
-        }
-      }
+      // 2. 해당 meeting의 creatorId가 user인지 확인 후 맞다면 위임 진행
+      delegatingCreator(meeting, user);
+
     }
 
     // 3. 모든 meeting 순회 종료 및 위임 또는 미팅 삭제 절차 종료
     // MeeetingMember에 있는 user 모두 삭제
-    if(!joinedMeetings.isEmpty()){
-      meetingMemberRepository.deleteAll(joinedMeetings);
+//    if(!joinedMeetings.isEmpty()){
+//      meetingMemberRepository.deleteAll(joinedMeetings);
+//    }
+  }
+
+  @Transactional
+  protected void delegatingCreator(Meeting meeting, User user) {
+    if(meeting.getUser().getId().equals(user.getId())){
+      // 맞다면 user를 제외한 가장 오래된 ACCEPT 멤버 찾기
+      Optional<MeetingMember> oldestMember =
+              meetingMemberRepository.findTopByMeetingAndUserNotAndStateOrderByCreatedAtAsc(meeting, user, State.ACCEPT);
+
+      if(oldestMember.isPresent()){
+        // 멤버가 있다면, creatorId 위임
+        User newCreator = oldestMember.get().getUser();
+        meeting.setUser(newCreator);
+        meetingRepository.saveAndFlush(meeting);
+      } else{
+        // 멤버가 없다면, 아무도 없는 것이므로 meeting 자체를 삭제
+        meetingRepository.delete(meeting);
+        meetingRepository.flush();
+      }
     }
+  }
+
+
+  // 모임 탈퇴하기
+  @Transactional
+  public void leaveMeeting(Long id, Long userId) {
+    MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(id, userId)
+            .orElseThrow(() -> new RuntimeException("해당 멤버가 없습니다."));
+
+    Meeting meeting = member.getMeeting();
+    User user = member.getUser();
+
+    // meetingmember에서의 user 삭제
+    meetingMemberRepository.delete(member);
+    meetingMemberRepository.flush();
+
+    // meeting에서의 권한 위임 또는 meeting 삭제
+    delegatingCreator(meeting, user);
+
+
+
+    // 멤버가 없을 시 모임 제거
+//    int memberCount = meetingMemberRepository.countByMeetingId(id);
+//    if(memberCount == 0){
+//      Meeting meeting = meetingRepository.findById(id)
+//          .orElseThrow(() -> new RuntimeException("모임을 찾지 못했습니다"));
+//      meetingRepository.delete(meeting);
+//    }
   }
 }

--- a/src/main/java/com/grepp/synapse4/app/model/meeting/VoteService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/meeting/VoteService.java
@@ -1,6 +1,7 @@
 package com.grepp.synapse4.app.model.meeting;
 
 import com.grepp.synapse4.app.model.meeting.code.State;
+import com.grepp.synapse4.app.model.user.entity.User;
 import com.grepp.synapse4.app.model.vote.dto.VoteDto;
 import com.grepp.synapse4.app.model.meeting.entity.Meeting;
 import com.grepp.synapse4.app.model.meeting.entity.MeetingMember;
@@ -138,5 +139,9 @@ public class VoteService {
   @Transactional(readOnly = true)
   public List<String> findJoinedNicknamesByVoteId(Long id, Boolean isJoined) {
     return voteMemberRepository.findNicknamesByVoteIdAndIsJoined(id, isJoined);
+  }
+
+  public void deleteByUser(User user) {
+    voteMemberRepository.deleteByUser(user);
   }
 }

--- a/src/main/java/com/grepp/synapse4/app/model/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/grepp/synapse4/app/model/meeting/repository/MeetingMemberRepository.java
@@ -2,10 +2,13 @@ package com.grepp.synapse4.app.model.meeting.repository;
 
 import com.grepp.synapse4.app.model.meeting.code.State;
 import com.grepp.synapse4.app.model.meeting.dto.AdminMeetingMemberDto;
+import com.grepp.synapse4.app.model.meeting.entity.Meeting;
 import com.grepp.synapse4.app.model.meeting.entity.MeetingMember;
 import com.grepp.synapse4.app.model.user.entity.User;
+
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,31 +16,34 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Long> {
-  List<MeetingMember> findAllByUserIdAndState(Long userId, State state);
-  List<MeetingMember> findAllByMeetingIdAndState(Long meeting_id, State state);
+    List<MeetingMember> findAllByUserIdAndState(Long userId, State state);
 
-  Optional<MeetingMember> findByMeetingIdAndUserId(Long meetingId, Long userId);
+    List<MeetingMember> findAllByMeetingIdAndState(Long meeting_id, State state);
 
-  Boolean existsAllByMeetingIdAndUserId(Long meetingId, Long userId);
+    Optional<MeetingMember> findByMeetingIdAndUserId(Long meetingId, Long userId);
 
-  Integer countByMeetingIdAndState(Long meetingId, State state);
+    Boolean existsAllByMeetingIdAndUserId(Long meetingId, Long userId);
 
-  Integer countByMeetingId(Long meetingId);
+    Integer countByMeetingIdAndState(Long meetingId, State state);
 
-  // 관리자페이지 모임멤버보기
-  @Query("""
-      select new com.grepp.synapse4.app.model.meeting.dto.AdminMeetingMemberDto(
-        mm.id,
-        mm.meeting.id,
-        mm.user.nickname
-      )
-      from MeetingMember mm
-      where mm.meeting.id = :meetingId
-    """)
-  List<AdminMeetingMemberDto> findUserNicknamesByMeetingId(@Param("meetingId") Long meetingId);
+    Integer countByMeetingId(Long meetingId);
 
-  void deleteByUser(User user);
+    // 관리자페이지 모임멤버보기
+    @Query("""
+              select new com.grepp.synapse4.app.model.meeting.dto.AdminMeetingMemberDto(
+                mm.id,
+                mm.meeting.id,
+                mm.user.nickname
+              )
+              from MeetingMember mm
+              where mm.meeting.id = :meetingId
+            """)
+    List<AdminMeetingMemberDto> findUserNicknamesByMeetingId(@Param("meetingId") Long meetingId);
 
-  List<MeetingMember> findAllByMeetingId(Long meetingId);
+    List<MeetingMember> findAllByMeetingId(Long meetingId);
 
+    List<MeetingMember> findAllByUser(User user);
+
+    // 이게 맞나 싶지만 맞긴 함...
+    Optional<MeetingMember> findTopByMeetingAndUserNotAndStateOrderByCreatedAtAsc(Meeting meeting, User user, State state);
 }

--- a/src/main/java/com/grepp/synapse4/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/UserService.java
@@ -1,24 +1,25 @@
 package com.grepp.synapse4.app.model.user;
 
-import static com.grepp.synapse4.app.model.auth.code.Role.ROLE_ADMIN;
-import static com.grepp.synapse4.app.model.auth.code.Role.ROLE_USER;
-
-import com.grepp.synapse4.app.model.meeting.repository.MeetingMemberRepository;
-import com.grepp.synapse4.app.model.vote.repository.VoteMemberRepository;
+import com.grepp.synapse4.app.model.meeting.MeetingService;
+import com.grepp.synapse4.app.model.meeting.VoteService;
 import com.grepp.synapse4.app.model.user.dto.request.EditInfoRequest;
 import com.grepp.synapse4.app.model.user.dto.request.UserSignUpRequest;
 import com.grepp.synapse4.app.model.user.dto.response.FindIdResponseDto;
 import com.grepp.synapse4.app.model.user.entity.User;
 import com.grepp.synapse4.app.model.user.repository.UserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.grepp.synapse4.app.model.auth.code.Role.ROLE_ADMIN;
+import static com.grepp.synapse4.app.model.auth.code.Role.ROLE_USER;
 
 @Service
 @Transactional
@@ -29,8 +30,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserValidator userValidator;
     private final MailService mailService;
-    private final MeetingMemberRepository meetingMemberRepository;
-    private final VoteMemberRepository voteMemberRepository;
+    private final MeetingService meetingService;
+    private final VoteService voteService;
 
     public List<User> findAll() {
         return userRepository.findAll();
@@ -118,8 +119,8 @@ public class UserService {
         user.setActivated(false);
         user.setDeletedAt(LocalDateTime.now());
 
-        meetingMemberRepository.deleteByUser(user);
-        voteMemberRepository.deleteByUser(user);
+        meetingService.deleteByUser(user);
+        voteService.deleteByUser(user);
 
         userRepository.save(user);
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
회원 탈퇴 시, 모임에 가입되어 있는 경우 처리
1. 가입된 meeting에서 삭제 처리(meetingMember에서 해당 userId 삭제)
2. 가입된 meeting의 creator일 때, 가장 오래 전 meetingmember로 추가된 회원을 creator로 위임
3. 가장 오래된 member가 없을 때 = 해당 meeting의 meetingmember가 삭제할 user 혼자일 때 -> meeting도 함께 삭제
4. voteMember에서도 userId 삭제

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
MeetingService가 본 구현의 핵심 로직입니다.
