### PR TITLE
Feat: Google OAuth2 소셜 로그인 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <version>0.12.6</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- oauth2 client -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>spring-boot-starter-batch</artifactId>
     </dependency>
 
+    <!-- oauth2 client -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
     <!-- redis -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,6 @@
       <version>0.12.6</version>
       <scope>runtime</scope>
     </dependency>
-    <!-- oauth2 client -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-client</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/grepp/synapse4/app/controller/web/oauth2/OAuth2Controller.java
+++ b/src/main/java/com/grepp/synapse4/app/controller/web/oauth2/OAuth2Controller.java
@@ -1,0 +1,79 @@
+package com.grepp.synapse4.app.controller.web.oauth2;
+
+import com.grepp.synapse4.app.model.auth.AuthService;
+import com.grepp.synapse4.app.model.auth.code.Provider;
+import com.grepp.synapse4.app.model.auth.code.Role;
+import com.grepp.synapse4.app.model.auth.token.dto.TokenDto;
+import com.grepp.synapse4.app.model.user.entity.User;
+import com.grepp.synapse4.app.model.user.repository.UserRepository;
+import com.grepp.synapse4.infra.auth.token.TokenCookieFactory;
+import com.grepp.synapse4.infra.auth.token.code.TokenType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/oauth2")
+@RequiredArgsConstructor
+public class OAuth2Controller {
+
+    private final UserRepository userRepository;
+    private final AuthService authService;
+
+    @GetMapping("/nickname")
+    public String showNicknamePage() {
+        return "oauth2/nickname";
+    }
+
+    @PostMapping("/nickname")
+    public String signupFromOAuth2(@RequestParam("nickname") String nickname,
+        HttpServletRequest request,
+        HttpServletResponse response) {
+
+        String email = (String) request.getSession().getAttribute("oauth2_email");
+        String providerId = (String) request.getSession().getAttribute("oauth2_providerId");
+        String providerName = (String) request.getSession().getAttribute("oauth2_provider");
+        String name = (String) request.getSession().getAttribute("oauth2_name");
+
+        Provider provider = Provider.valueOf(providerName);
+
+        if (userRepository.existsByNickname(nickname)) {
+            return "redirect:/oauth2/nickname?error=duplicated";
+        }
+
+        User user = User.builder()
+            .userAccount(provider.name().toLowerCase() + "_" + providerId)
+            .password(null)
+            .email(email)
+            .name(name)
+            .nickname(nickname)
+            .isSurvey(false)
+            .activated(true)
+            .role(Role.ROLE_USER)
+            .provider(provider)
+            .providerId(providerId)
+            .build();
+
+        userRepository.save(user);
+
+        // JWT 발급 및 쿠키 저장
+        TokenDto tokenDto = authService.processTokenSignin(user);
+
+        ResponseCookie accessTokenCookie = TokenCookieFactory.create(TokenType.ACCESS_TOKEN.name(),
+            tokenDto.getAccessToken(), tokenDto.getAtExpiresIn());
+        ResponseCookie refreshTokenCookie = TokenCookieFactory.create(TokenType.REFRESH_TOKEN.name(),
+            tokenDto.getRefreshToken(), tokenDto.getRtExpiresIn());
+
+        response.addHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        return "redirect:/";
+    }
+}
+

--- a/src/main/java/com/grepp/synapse4/app/model/auth/code/Provider.java
+++ b/src/main/java/com/grepp/synapse4/app/model/auth/code/Provider.java
@@ -1,0 +1,6 @@
+package com.grepp.synapse4.app.model.auth.code;
+
+public enum Provider {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/com/grepp/synapse4/app/model/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/dto/request/UserSignUpRequest.java
@@ -1,6 +1,7 @@
 package com.grepp.synapse4.app.model.user.dto.request;
 
 import com.grepp.synapse4.app.model.auth.code.Role;
+import com.grepp.synapse4.app.model.auth.code.Provider;
 import com.grepp.synapse4.app.model.user.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -45,6 +46,8 @@ public class UserSignUpRequest {
             .isSurvey(false)
             .activated(true)
             .role(role)
+            .provider(Provider.LOCAL)
+            .providerId(null)
             .build();
     }
 }

--- a/src/main/java/com/grepp/synapse4/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.grepp.synapse4.app.model.user.entity;
 
 import com.grepp.synapse4.app.model.auth.code.Role;
+import com.grepp.synapse4.app.model.auth.code.Provider;
 import com.grepp.synapse4.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,7 +32,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String userAccount;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Column(nullable = false)
@@ -55,10 +56,19 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider; // 계정 출처 구분(ex_local, google 등)
+
+    @Column
+    private String providerId;  // 소셜 로그인의 고유 사용자 id 값
+
+
     @Builder
-    private User(String userAccount, String password, String name, String nickname, String email,
-        Boolean isSurvey,
-        Boolean activated, LocalDateTime deletedAt, Role role) {
+    public User(String userAccount, String password, String name, String nickname, String email,
+        Boolean isSurvey, Boolean activated, LocalDateTime deletedAt, Role role, Provider provider,
+        String providerId) {
         this.userAccount = userAccount;
         this.password = password;
         this.name = name;
@@ -68,6 +78,8 @@ public class User extends BaseEntity {
         this.activated = activated;
         this.deletedAt = deletedAt;
         this.role = role;
+        this.provider = provider;
+        this.providerId = providerId;
     }
 
     public User(String userAccount, String name, String email) {

--- a/src/main/java/com/grepp/synapse4/app/model/user/repository/UserRepository.java
+++ b/src/main/java/com/grepp/synapse4/app/model/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.grepp.synapse4.app.model.user.repository;
 
+import com.grepp.synapse4.app.model.auth.code.Provider;
 import com.grepp.synapse4.app.model.user.dto.AdminUserSearchDto;
 import com.grepp.synapse4.app.model.user.entity.User;
 
@@ -16,8 +17,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNameAndEmail(String name, String email);
     Optional<User> findByUserAccountAndNameAndEmail(String userAccount, String name, String email);
+    Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
     boolean existsByUserAccount(String userAccount);
+    boolean existsByNickname(String nickname);
 
     List<AdminUserSearchDto> findByUserAccountContaining(String userAccount);
 

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,46 @@
+package com.grepp.synapse4.infra.auth.oauth2;
+
+import com.grepp.synapse4.app.model.auth.AuthService;
+import com.grepp.synapse4.app.model.auth.token.RefreshTokenService;
+import com.grepp.synapse4.infra.auth.token.JwtProvider;
+import com.grepp.synapse4.infra.auth.token.TokenCookieFactory;
+import com.grepp.synapse4.infra.auth.token.code.TokenType;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final AuthService authService;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException, ServletException {
+
+        String requestAccessToken = jwtProvider.resolveToken(request, TokenType.ACCESS_TOKEN);
+        if (requestAccessToken == null) {
+            return;
+        }
+
+        Claims claims = jwtProvider.parseClaim(requestAccessToken);
+        refreshTokenService.deleteByAccessTokenId(claims.getId());
+
+        ResponseCookie expiredAccessToken = TokenCookieFactory.createExpiredToken(TokenType.ACCESS_TOKEN);
+        ResponseCookie expiredRefreshToken = TokenCookieFactory.createExpiredToken(TokenType.REFRESH_TOKEN);
+        response.addHeader("Set-Cookie", expiredAccessToken.toString());
+        response.addHeader("Set-Cookie", expiredRefreshToken.toString());
+        getRedirectStrategy().sendRedirect(request, response, "/");
+    }
+
+}

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -1,40 +1,78 @@
 package com.grepp.synapse4.infra.auth.oauth2;
 
 import com.grepp.synapse4.app.model.auth.AuthService;
-import jakarta.servlet.ServletException;
+import com.grepp.synapse4.app.model.auth.code.Provider;
+import com.grepp.synapse4.app.model.auth.token.dto.TokenDto;
+import com.grepp.synapse4.app.model.user.entity.User;
+import com.grepp.synapse4.app.model.user.repository.UserRepository;
+import com.grepp.synapse4.infra.auth.oauth2.user.OAuth2UserInfo;
+import com.grepp.synapse4.infra.auth.oauth2.user.OAuth2UserInfoFactory;
+import com.grepp.synapse4.infra.auth.token.TokenCookieFactory;
+import com.grepp.synapse4.infra.auth.token.code.TokenType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    private final UserRepository userRepository;
     private final AuthService authService;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication) throws IOException {
 
-        OAuth2User user = (OAuth2User) authentication.getPrincipal();
-        OAuth2UserInfo userInfo = OAuth2UserInfo.create(request.getRequestURI(), user);
-        TokenDto dto = authService.processTokenSignin(userInfo.getName());
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String     registrationId = "google";              // 현재 구글만 사용
+        OAuth2UserInfo userInfo   = OAuth2UserInfoFactory.create(registrationId, oAuth2User);
 
-        ResponseCookie accessTokenCookie = TokenCookieFactory.create(TokenType.ACCESS_TOKEN.name(),
-            dto.getAccessToken(), dto.getAtExpiresIn());
-        ResponseCookie refreshTokenCookie = TokenCookieFactory.create(TokenType.REFRESH_TOKEN.name(),
-            dto.getRefreshToken(), dto.getRtExpiresIn());
+        // 1. 이미 로컬 가입된 이메일이면 소셜 로그인 차단
+        Optional<User> emailUser = userRepository.findByEmail(userInfo.getEmail());
+        if (emailUser.isPresent() && emailUser.get().getProvider() == Provider.LOCAL) {
+            response.sendRedirect("/user/signin?error=already_local");
+            return;
+        }
 
-        response.addHeader("Set-Cookie", accessTokenCookie.toString());
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-        getRedirectStrategy().sendRedirect(request,response,"/");
+        // 기존 소셜 유저이면 바로 JWT 발급 → 쿠키로 내려주고 홈으로
+        Optional<User> socialUser =
+            userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId());
+
+        if (socialUser.isPresent()) {
+            TokenDto dto = authService.processTokenSignin(socialUser.get());
+
+            ResponseCookie accessCookie  = TokenCookieFactory.create(
+                TokenType.ACCESS_TOKEN.name(),
+                dto.getAccessToken(),
+                dto.getAtExpiresIn());
+
+            ResponseCookie refreshCookie = TokenCookieFactory.create(
+                TokenType.REFRESH_TOKEN.name(),
+                dto.getRefreshToken(),
+                dto.getRtExpiresIn());
+
+            response.addHeader("Set-Cookie", accessCookie.toString());
+            response.addHeader("Set-Cookie", refreshCookie.toString());
+            response.sendRedirect("/");
+            return;
+        }
+
+        // 3. 신규 소셜 유저 -> 닉네임 설정 페이지
+        request.getSession().setAttribute("oauth2_email",      userInfo.getEmail());
+        request.getSession().setAttribute("oauth2_providerId", userInfo.getProviderId());
+        request.getSession().setAttribute("oauth2_provider",   userInfo.getProvider().name());
+        request.getSession().setAttribute("oauth2_name",       userInfo.getName());
+        response.sendRedirect("/oauth2/nickname");
     }
-
 }

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,40 @@
+package com.grepp.synapse4.infra.auth.oauth2;
+
+import com.grepp.synapse4.app.model.auth.AuthService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        OAuth2User user = (OAuth2User) authentication.getPrincipal();
+        OAuth2UserInfo userInfo = OAuth2UserInfo.create(request.getRequestURI(), user);
+        TokenDto dto = authService.processTokenSignin(userInfo.getName());
+
+        ResponseCookie accessTokenCookie = TokenCookieFactory.create(TokenType.ACCESS_TOKEN.name(),
+            dto.getAccessToken(), dto.getAtExpiresIn());
+        ResponseCookie refreshTokenCookie = TokenCookieFactory.create(TokenType.REFRESH_TOKEN.name(),
+            dto.getRefreshToken(), dto.getRtExpiresIn());
+
+        response.addHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+        getRedirectStrategy().sendRedirect(request,response,"/");
+    }
+
+}

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/GoogleOAuth2UserInfo.java
@@ -1,0 +1,34 @@
+package com.grepp.synapse4.infra.auth.oauth2.user;
+
+import com.grepp.synapse4.app.model.auth.code.Provider;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final OAuth2User oAuth2User;
+
+    public GoogleOAuth2UserInfo(OAuth2User oAuth2User) {
+        this.oAuth2User = oAuth2User;
+    }
+
+    @Override
+    public String getProviderId() {
+        return oAuth2User.getAttribute("sub"); // 구글의 고유 ID
+    }
+
+    @Override
+    public String getEmail() {
+        return oAuth2User.getAttribute("email");
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2User.getAttribute("name");
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
+}
+

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,10 @@
+package com.grepp.synapse4.infra.auth.oauth2.user;
+
+import com.grepp.synapse4.app.model.auth.code.Provider;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getEmail();
+    String getName();
+    Provider getProvider();
+}

--- a/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/grepp/synapse4/infra/auth/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,12 @@
+package com.grepp.synapse4.infra.auth.oauth2.user;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo create(String registrationId, OAuth2User user) {
+        return switch (registrationId.toLowerCase()) {
+            case "google" -> new GoogleOAuth2UserInfo(user);
+            default -> throw new IllegalArgumentException("지원하지 않는 OAuth2 제공자입니다: " + registrationId);
+        };
+    }
+}

--- a/src/main/java/com/grepp/synapse4/infra/config/RedisConfig.java
+++ b/src/main/java/com/grepp/synapse4/infra/config/RedisConfig.java
@@ -58,7 +58,7 @@ public class RedisConfig {
         mapper.activateDefaultTyping(
             BasicPolymorphicTypeValidator.builder()
                 .allowIfBaseType("org.springframework.security.") // 기존 설정 (유지)
-                .allowIfBaseType("com.grepp.spring.")    // 당신의 도메인 객체 패키지 (유지)
+                .allowIfBaseType("com.grepp.synapse4.")    // 당신의 도메인 객체 패키지 (유지)
                 .build(),
             ObjectMapper.DefaultTyping.NON_FINAL,
             JsonTypeInfo.As.PROPERTY

--- a/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.grepp.synapse4.infra.config;
 
 import static org.springframework.http.HttpMethod.POST;
 
+import com.grepp.synapse4.infra.auth.oauth2.OAuth2FailureHandler;
+import com.grepp.synapse4.infra.auth.oauth2.OAuth2SuccessHandler;
 import com.grepp.synapse4.infra.auth.token.JwtAuthenticationEntryPoint;
 import com.grepp.synapse4.infra.auth.token.filter.AuthExceptionFilter;
 import com.grepp.synapse4.infra.auth.token.filter.JwtAuthenticationFilter;
@@ -35,6 +37,9 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint entryPoint;
     private final LogoutFilter logoutFilter;
 
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -48,10 +53,11 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
-//            // oauth 2.0 login
-//            .oauth2Login(oauth -> oauth.successHandler(oAuth2SuccessHandler)
-//                .failureHandler(oAuth2FailureHandler)
-//            )
+            // oauth 2.0 login
+            .oauth2Login(oauth -> oauth
+                .successHandler(oAuth2SuccessHandler)
+                .failureHandler(oAuth2FailureHandler)
+            )
 
             .authorizeHttpRequests(auth -> auth
                 // 관리자(admin)

--- a/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
@@ -48,10 +48,10 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
-            // oauth 2.0 login
-            .oauth2Login(oauth -> oauth.successHandler(oAuth2SuccessHandler)
-                .failureHandler(oAuth2FailureHandler)
-            )
+//            // oauth 2.0 login
+//            .oauth2Login(oauth -> oauth.successHandler(oAuth2SuccessHandler)
+//                .failureHandler(oAuth2FailureHandler)
+//            )
 
             .authorizeHttpRequests(auth -> auth
                 // 관리자(admin)

--- a/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/synapse4/infra/config/SecurityConfig.java
@@ -48,6 +48,11 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
+            // oauth 2.0 login
+            .oauth2Login(oauth -> oauth.successHandler(oAuth2SuccessHandler)
+                .failureHandler(oAuth2FailureHandler)
+            )
+
             .authorizeHttpRequests(auth -> auth
                 // 관리자(admin)
                 .requestMatchers(

--- a/src/main/java/com/grepp/synapse4/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/synapse4/infra/error/RestApiExceptionAdvice.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(basePackages = "com.grepp.spring.app.controller.api")
+@RestControllerAdvice(basePackages = "com.grepp.synapse4.app.controller.api")
 @Slf4j
 public class RestApiExceptionAdvice {
     

--- a/src/main/java/com/grepp/synapse4/infra/error/WebExceptionAdvice.java
+++ b/src/main/java/com/grepp/synapse4/infra/error/WebExceptionAdvice.java
@@ -6,7 +6,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-@ControllerAdvice(basePackages = "com.grepp.spring.app.controller.web")
+@ControllerAdvice(basePackages = "com.grepp.synapse4.app.controller.web")
 public class WebExceptionAdvice {
     
     @ExceptionHandler(CommonException.class)

--- a/src/main/java/com/grepp/synapse4/infra/error/exceptions/LocalUserExistsException.java
+++ b/src/main/java/com/grepp/synapse4/infra/error/exceptions/LocalUserExistsException.java
@@ -1,0 +1,7 @@
+package com.grepp.synapse4.infra.error.exceptions;
+
+public class LocalUserExistsException extends RuntimeException {
+    public LocalUserExistsException() {
+        super("이미 로컬 계정으로 가입된 이메일입니다.");
+    }
+}

--- a/src/main/java/com/grepp/synapse4/infra/error/exceptions/NeedNicknameRegistrationException.java
+++ b/src/main/java/com/grepp/synapse4/infra/error/exceptions/NeedNicknameRegistrationException.java
@@ -1,0 +1,14 @@
+package com.grepp.synapse4.infra.error.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public class NeedNicknameRegistrationException extends RuntimeException {
+    private final String email;
+
+    public NeedNicknameRegistrationException(String email) {
+        super("닉네임 설정이 필요한 사용자입니다.");
+        this.email = email;
+    }
+
+}

--- a/src/main/resources/templates/oauth2/nickname.html
+++ b/src/main/resources/templates/oauth2/nickname.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko"
+      layout:decorate="~{layout}"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>닉네임 설정</title>
+</head>
+<body>
+<main layout:fragment="content">
+  <div class="flex justify-center items-center min-h-screen bg-white">
+    <div class="bg-gray-100 p-10 rounded-lg shadow-md w-full max-w-xl text-center">
+      <h2 class="text-2xl font-bold mb-6">서비스 이용을 위해 닉네임을 설정해주세요</h2>
+
+      <form class="space-y-4" method="post" th:action="@{/oauth2/nickname}">
+        <input class="w-full border border-gray-300 rounded px-4 py-2" name="nickname"
+               placeholder="닉네임 입력" required type="text">
+
+        <button class="w-1/2 text-white py-3 rounded" style="background-color: #27a69a;"
+                type="submit">
+          등록하기
+        </button>
+      </form>
+
+      <div class="mt-4 text-red-600 font-medium" th:if="${param.error}">
+        이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/user/signin.html
+++ b/src/main/resources/templates/user/signin.html
@@ -54,7 +54,6 @@
 
         <!-- 구글 로그인 -->
         <div class="mt-6 flex flex-col gap-3">
-          <!-- Google -->
           <a href="/oauth2/authorization/google"
              class="w-full flex items-center justify-center gap-2 border border-gray-300 bg-white text-gray-700 py-3 rounded-md shadow hover:bg-gray-100 transition">
             <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" class="w-5 h-5" alt="Google"/>

--- a/src/main/resources/templates/user/signin.html
+++ b/src/main/resources/templates/user/signin.html
@@ -12,21 +12,25 @@
     <div class="signin-container bg-gray-100 p-12 rounded-lg shadow-md w-full max-w-3xl">
       <div class="text-2xl font-bold text-center mb-8">로그인</div>
       <form class="space-y-4" id="signin-form">
-        <div class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded text-center"
-             id="error-msg">
+
+        <div
+            class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded text-center"
+            id="error-msg">
           아이디 또는 비밀번호가 일치하지 않습니다.
         </div>
 
         <div class="form-group">
           <label class="font-semibold" for="userAccount">아이디</label>
-          <input class="w-full border border-gray-300 rounded px-3 py-2" id="userAccount" name="userAccount"
+          <input class="w-full border border-gray-300 rounded px-3 py-2" id="userAccount"
+                 name="userAccount"
                  placeholder="아이디를 입력해주세요"
                  required type="text"/>
         </div>
 
         <div class="form-group">
           <label class="font-semibold" for="password">비밀번호</label>
-          <input class="w-full border border-gray-300 rounded px-3 py-2" id="password" name="password"
+          <input class="w-full border border-gray-300 rounded px-3 py-2" id="password"
+                 name="password"
                  placeholder="비밀번호를 입력해주세요"
                  required type="password"/>
         </div>
@@ -44,16 +48,38 @@
         </div>
 
         <div class="text-center mt-2 space-x-4">
-          <a class="text-sm text-gray-600 underline hover:text-gray-800" style="text-decoration: none;"
+          <a class="text-sm text-gray-600 underline hover:text-gray-800"
+             style="text-decoration: none;"
              th:href="@{/user/find-id}">아이디 찾기</a>
           <span class="text-gray-400">|</span>
           <a class="text-sm text-gray-600 underline hover:text-gray-800"
              style="text-decoration: none;"
              th:href="@{/user/find-password}">비밀번호 찾기</a>
         </div>
+
+        <!-- 구글 로그인 버튼 -->
+        <div class="mt-6">
+          <a class="flex items-center justify-center gap-3 w-1/2 py-3 px-4 border border-gray-300 rounded-lg shadow-sm
+            hover:bg-gray-100 transition bg-white"
+             href="/oauth2/authorization/google">
+            <img alt="Google Logo" class="w-5 h-5"
+                 src="https://developers.google.com/identity/images/g-logo.png">
+            <span class="text-sm font-medium text-gray-700">Google 계정으로 시작하기</span>
+          </a>
+        </div>
+
       </form>
     </div>
   </div>
+
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('error') === 'already_local') {
+      alert('해당 이메일로 가입된 계정이 있습니다. 기존 계정으로 로그인해주세요.');
+      window.location.href = '/user/signin';
+    }
+  </script>
+
   <script>
     document.getElementById("signin-form").addEventListener("submit", async function (e) {
       e.preventDefault();

--- a/src/main/resources/templates/user/signin.html
+++ b/src/main/resources/templates/user/signin.html
@@ -9,8 +9,9 @@
 <body>
 <main layout:fragment="content">
   <div class="flex justify-center items-center min-h-screen bg-white">
-    <div class="signin-container bg-gray-100 p-12 rounded-lg shadow-md w-full max-w-3xl">
-      <div class="text-2xl font-bold text-center mb-8">로그인</div>
+    <div class="bg-gray-100 p-10 rounded-xl shadow-lg w-full max-w-md">
+      <div class="text-2xl font-bold text-center mb-6">로그인</div>
+
       <form class="space-y-4" id="signin-form">
 
         <div
@@ -35,39 +36,37 @@
                  required type="password"/>
         </div>
 
-        <div class="flex justify-center" style="margin-top: 35px;">
-          <button class="w-1/2 text-white py-3 rounded" style="background-color: #27a69a;"
-                  type="submit">
+        <div>
+          <button type="submit"
+                  class="w-full text-white font-semibold py-3 rounded-md shadow hover:brightness-110 transition"
+                  style="background-color: #27a69a;">
             로그인
           </button>
         </div>
 
-        <div class="text-center mt-4">
-          <a class="text-sm text-black underline hover:text-gray-800" style="text-decoration: none;"
-             th:href="@{/user/signup}">회원가입</a>
+        <div class="flex justify-end items-center text-sm text-gray-400 mt-1">
+          <div class="space-x-2">
+            <a th:href="@{/user/find-id}" class="text-gray-400 hover:text-gray-600 hover:underline no-visited">아이디 찾기</a>
+            <span>|</span>
+            <a th:href="@{/user/find-password}" class="text-gray-400 hover:text-gray-600 hover:underline no-visited">비밀번호 찾기</a>
+          </div>
         </div>
 
-        <div class="text-center mt-2 space-x-4">
-          <a class="text-sm text-gray-600 underline hover:text-gray-800"
-             style="text-decoration: none;"
-             th:href="@{/user/find-id}">아이디 찾기</a>
-          <span class="text-gray-400">|</span>
-          <a class="text-sm text-gray-600 underline hover:text-gray-800"
-             style="text-decoration: none;"
-             th:href="@{/user/find-password}">비밀번호 찾기</a>
-        </div>
-
-        <!-- 구글 로그인 버튼 -->
-        <div class="mt-6">
-          <a class="flex items-center justify-center gap-3 w-1/2 py-3 px-4 border border-gray-300 rounded-lg shadow-sm
-            hover:bg-gray-100 transition bg-white"
-             href="/oauth2/authorization/google">
-            <img alt="Google Logo" class="w-5 h-5"
-                 src="https://developers.google.com/identity/images/g-logo.png">
-            <span class="text-sm font-medium text-gray-700">Google 계정으로 시작하기</span>
+        <!-- 구글 로그인 -->
+        <div class="mt-6 flex flex-col gap-3">
+          <!-- Google -->
+          <a href="/oauth2/authorization/google"
+             class="w-full flex items-center justify-center gap-2 border border-gray-300 bg-white text-gray-700 py-3 rounded-md shadow hover:bg-gray-100 transition">
+            <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" class="w-5 h-5" alt="Google"/>
+            <span class="font-medium">Google 계정으로 시작하기</span>
           </a>
         </div>
 
+        <div class="text-center mt-6 text-sm">
+          <a th:href="@{/user/signup}" class="text-black underline hover:text-gray-900">
+            회원가입
+          </a>
+        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- google 소셜 로그인 기능 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 구글 로그인 동작 흐름
1. 사용자가 /oauth2/authorization/google로 로그인 요청
2. 구글 인증 성공 -> OAuth2SuccessHandler 진입
3. 구글에서 받은 사용자 정보 추출
4. 이메일 기준 -> UserRepository에서 기존 사용자 조회
5. 조건 분기 처리
- 기존 Local 회원: /user/signin?error=already_local 리다이렉트 (로컬 로그인 페이지로 리다이렉트 되고, alert 메시지가 뜹니다)
- 기존 OAuth2 회원: JWT 발급 → 쿠키 저장 → 메인 페이지 리다이렉트 (로그인 처리)
- 신규 사용자:  /user/nickname 페이지로 이동 -> 닉네임 설정 완료 시 JWT 발급, 쿠키 저장 -> 메인 페이지 리다이렉트
6. 로그아웃 -> LogoutFilter가 accessToken 블랙리스트 등록 및 refreshToken 삭제

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 로그인 로직 분기 처리가 맞는지 확인 부탁드립니다.